### PR TITLE
fix: stop querying if response is not a successful translation

### DIFF
--- a/translation.py
+++ b/translation.py
@@ -9,7 +9,7 @@ headers = {"Authorization": f"Bearer {os.getenv('HUGGINGFACE_ACCESS_TOKEN')}"}
 
 def query(payload):
     response = requests.post(API_URL, headers=headers, json=payload)
-    return response.json()
+    return response.json(), response.status_code
 
 
 recipe_df = pd.read_csv('./translated_all_recipes.csv')
@@ -17,9 +17,12 @@ recipe_df = pd.read_csv('./translated_all_recipes.csv')
 for i, ingr in enumerate(recipe_df['ingredients']):
     if not pd.isnull(recipe_df.loc[i, 'eng_ingredients']):
         continue
-    output = query({
+    output, status_code = query({
         "inputs": ingr,
     })
+    if status_code != 200:
+        print(output)
+        break
     print(f"{i} out of {len(recipe_df)} | {output}")
     recipe_df.loc[i, 'eng_ingredients'] = output[0]['translation_text']
     recipe_df.to_csv('./translated_all_recipes.csv', index=False)


### PR DESCRIPTION
If the huggingface API responds with an unsuccessful status it usually means we have reached the rate limit of the free API. In that case we should stop querying and return.